### PR TITLE
Fix methodinfo with different classloader

### DIFF
--- a/xposedcompat/src/main/java/com/swift/sandhook/xposedcompat/classloaders/ProxyClassLoader.java
+++ b/xposedcompat/src/main/java/com/swift/sandhook/xposedcompat/classloaders/ProxyClassLoader.java
@@ -2,11 +2,21 @@ package com.swift.sandhook.xposedcompat.classloaders;
 
 public class ProxyClassLoader extends ClassLoader {
 
-    private final ClassLoader mClassLoader;
+    private ClassLoader mClassLoader;
 
     public ProxyClassLoader(ClassLoader parentCL, ClassLoader appCL) {
         super(parentCL);
         mClassLoader = appCL;
+    }
+
+    public ProxyClassLoader(ClassLoader parent)
+    {
+        super(parent);
+    }
+
+    public void setChild(ClassLoader child)
+    {
+        mClassLoader = child;
     }
 
     @Override
@@ -21,7 +31,7 @@ public class ProxyClassLoader extends ClassLoader {
         if (clazz == null) {
             clazz = super.loadClass(name, resolve);
             if (clazz == null) {
-                throw new ClassNotFoundException();
+                throw new ClassNotFoundException("class not found in this scope "+name);
             }
         }
 


### PR DESCRIPTION
Some AdditionalHookInfo instance may create by ProxyClassLoader instead of class that already loaded with classloader that same as XposedBridge's classloader.
Invert hookMethod.getDeclaringClass().getClassLoader() and DynamicBridge.class.getClassLoader() may fix.
This problem may lead for crash (also bootloop) with EdXposed+MIUI12 device or make module lose efficacy with SandVXposed+MIUI12 device.
修复了类加载器引起的EdXposed当中小米设备无限重启或者模块失效的问题。
XposedHelpers.setStaticObjectField(mHookClass, FIELD_NAME_HOOK_INFO, mHookInfo);
报错修复以及部分安卓10+设备的错误修复。
有的手机应用PathClassLoader就是能加载出来Xposed类，或者因为某些玄学原因（应用加固改了环境等等）XposedBridge的类跟DexMaker的类加载器不同，会出现一些有趣的问题。