### PR TITLE
Fix pending hook on R

### DIFF
--- a/hooklib/src/main/cpp/includes/hide_api.h
+++ b/hooklib/src/main/cpp/includes/hide_api.h
@@ -54,6 +54,8 @@ extern "C" {
     JNIEnv *attachAndGetEvn();
 
     ArtMethod* getArtMethod(JNIEnv *env, jobject method);
+
+    void MakeInitializedClassVisibilyInitialized(void* self);
 }
 
 #endif //SANDHOOK_HIDE_API_H

--- a/hooklib/src/main/cpp/sandhook.cpp
+++ b/hooklib/src/main/cpp/sandhook.cpp
@@ -410,7 +410,12 @@ JNIEXPORT bool nativeHookNoBackup(void* origin, void* hook) {
     return trampolineManager.installNativeHookTrampolineNoBackup(origin, hook) != nullptr;
 
 }
-
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_swift_sandhook_SandHook_MakeInitializedClassVisibilyInitialized(JNIEnv *env, jclass clazz,
+                                                                         jlong self) {
+    MakeInitializedClassVisibilyInitialized(reinterpret_cast<void*>(self));
+}
 extern "C"
 JNIEXPORT void* findSym(const char *elf, const char *sym_name) {
     SandHook::ElfImg elfImg(elf);
@@ -497,6 +502,11 @@ static JNINativeMethod jniSandHook[] = {
                 "initForPendingHook",
                 "()Z",
                 (void *) Java_com_swift_sandhook_SandHook_initForPendingHook
+        },
+        {
+            "MakeInitializedClassVisibilyInitialized",
+                "(J)V",
+                (void*) Java_com_swift_sandhook_SandHook_MakeInitializedClassVisibilyInitialized
         }
 };
 

--- a/hooklib/src/main/java/com/swift/sandhook/SandHook.java
+++ b/hooklib/src/main/java/com/swift/sandhook/SandHook.java
@@ -97,6 +97,7 @@ public class SandHook {
             return;
         } else if (entity.initClass) {
             resolveStaticMethod(target);
+            MakeInitializedClassVisibilyInitialized(getThreadId());
         }
 
         resolveStaticMethod(backup);
@@ -402,6 +403,8 @@ public class SandHook {
     public static native boolean setNativeEntry(Member origin, Member hook, long nativeEntry);
 
     public static native boolean initForPendingHook();
+
+    public static native void MakeInitializedClassVisibilyInitialized(long self);
 
     @FunctionalInterface
     public interface HookModeCallBack {

--- a/hooklib/src/main/java/com/swift/sandhook/utils/ClassStatusUtils.java
+++ b/hooklib/src/main/java/com/swift/sandhook/utils/ClassStatusUtils.java
@@ -2,9 +2,9 @@ package com.swift.sandhook.utils;
 
 import com.swift.sandhook.SandHookConfig;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 public class ClassStatusUtils {
@@ -43,11 +43,15 @@ public class ClassStatusUtils {
      * 5.0-8.0: kInitialized = 10 int
      * 8.1:     kInitialized = 11 int
      * 9.0:     kInitialized = 14 uint8_t
+     * 11.0+:   kInitialized = 14 uint8_t
+     *          kVisiblyInitialized = 15 uint8_t
      */
     public static boolean isInitialized(Class clazz) {
         if (fieldStatusOfClass == null)
             return true;
-        if (SandHookConfig.SDK_INT >= 28) {
+        if (SandHookConfig.SDK_INT >= 30) {
+            return getClassStatus(clazz, true) >= 14;
+        } else if (SandHookConfig.SDK_INT >= 28) {
             return getClassStatus(clazz, true) == 14;
         } else if (SandHookConfig.SDK_INT == 27) {
             return getClassStatus(clazz, false) == 11;
@@ -57,7 +61,7 @@ public class ClassStatusUtils {
     }
 
     public static boolean isStaticAndNoInited(Member hookMethod) {
-        if (hookMethod == null || hookMethod instanceof Constructor) {
+        if (!(hookMethod instanceof Method)) {
             return false;
         }
         Class declaringClass = hookMethod.getDeclaringClass();

--- a/nativehook/src/main/cpp/archs/arm/arm32/hook/hook_arm32.cpp
+++ b/nativehook/src/main/cpp/archs/arm/arm32/hook/hook_arm32.cpp
@@ -106,7 +106,7 @@ bool InlineHookArm32Android::BreakPoint(void *origin, void (*callback)(REG *)) {
     try {
         backup = relocate.Relocate(origin, change_mode ? (4 * 2 + 2) : (4 * 2), nullptr);
     } catch (ErrorCodeException e) {
-        return nullptr;
+        return false;
     }
 #define __ assembler_backup.
     Label* origin_addr_label = new Label();
@@ -240,7 +240,7 @@ bool InlineHookArm32Android::SingleBreakPoint(void *point, BreakCallback callbac
         try {
             backup = relocate.Relocate(point, code_container_inline->Size(), nullptr);
         } catch (ErrorCodeException e) {
-            return nullptr;
+            return false;
         }
     } else {
         // a32 emit directly temp


### PR DESCRIPTION
In android R, FixupStaticTrampolines won't be called unless it's marking it as visiblyInitialized.
So we miss some calls between initialized and visiblyInitialized.
Therefore we hook the newly introduced MarkClassInitialized instead.

Tested on LSPosed:
https://github.com/LSPosed/LSPosed/commit/e5379ea27ee682e6f0f1fe1c4d2bf61f9a1d0077
https://github.com/LSPosed/LSPosed/commit/b27398fbe0b71b183c32d03cabfc30646a052af4