### PR TITLE
Fix crash on android 12

### DIFF
--- a/hooklib/src/main/cpp/casts/cast_art_method.cpp
+++ b/hooklib/src/main/cpp/casts/cast_art_method.cpp
@@ -150,10 +150,13 @@ namespace SandHook {
     class CastDexMethodIndex : public IMember<art::mirror::ArtMethod, uint32_t> {
     protected:
         Size calOffset(JNIEnv *jniEnv, art::mirror::ArtMethod *p) override {
-            if (SDK_INT >= ANDROID_P) {
+            if (SDK_INT >= ANDROID_S) {
                 return CastArtMethod::accessFlag->getOffset()
-                + CastArtMethod::accessFlag->size()
-                + sizeof(uint32_t);
+                       + CastArtMethod::accessFlag->size();
+            } else if (SDK_INT >= ANDROID_P) {
+                return CastArtMethod::accessFlag->getOffset()
+                       + CastArtMethod::accessFlag->size()
+                       + sizeof(uint32_t);
             }
             int offset = 0;
             jint index = getIntFromJava(jniEnv, "com/swift/sandhook/SandHookMethodResolver",

--- a/hooklib/src/main/cpp/includes/arch.h
+++ b/hooklib/src/main/cpp/includes/arch.h
@@ -44,5 +44,6 @@ static void clearCacheArm32(char* begin, char *end)
 #define ANDROID_P 28
 #define ANDROID_Q 29
 #define ANDROID_R 30
+#define ANDROID_S 31
 
 #endif //SANDHOOK_ARCH_H

--- a/hooklib/src/main/cpp/includes/hide_api.h
+++ b/hooklib/src/main/cpp/includes/hide_api.h
@@ -55,7 +55,7 @@ extern "C" {
 
     ArtMethod* getArtMethod(JNIEnv *env, jobject method);
 
-    void MakeInitializedClassVisibilyInitialized(void* self);
+    void MakeInitializedClassVisibilyInitialized(JNIEnv *env, void* self);
 }
 
 #endif //SANDHOOK_HIDE_API_H

--- a/hooklib/src/main/cpp/includes/trampoline.h
+++ b/hooklib/src/main/cpp/includes/trampoline.h
@@ -116,6 +116,8 @@ namespace SandHook {
 
         Trampoline() = default;
 
+        virtual ~Trampoline() = default;
+
         virtual void init() {
             codeLen = codeLength();
             tempCode = templateCode();

--- a/hooklib/src/main/cpp/includes/trampoline_manager.h
+++ b/hooklib/src/main/cpp/includes/trampoline_manager.h
@@ -27,6 +27,24 @@ namespace SandHook {
 
         HookTrampoline() = default;
 
+        ~ HookTrampoline() {
+            if (replacement) {
+                delete replacement;
+            }
+            if (inlineJump) {
+                delete inlineJump;
+            }
+            if (inlineSecondory) {
+                delete inlineSecondory;
+            }
+            if (callOrigin) {
+                delete callOrigin;
+            }
+            if (hookNative) {
+                delete hookNative;
+            }
+        };
+
         Trampoline* replacement = nullptr;
         Trampoline* inlineJump = nullptr;
         Trampoline* inlineSecondory = nullptr;

--- a/hooklib/src/main/cpp/sandhook.cpp
+++ b/hooklib/src/main/cpp/sandhook.cpp
@@ -94,7 +94,8 @@ bool doHookWithReplacement(JNIEnv* env,
     originMethod->disableInterpreterForO();
     originMethod->disableFastInterpreterForQ();
 
-    SandHook::HookTrampoline* hookTrampoline = trampolineManager.installReplacementTrampoline(originMethod, hookMethod, backupMethod);
+    std::unique_ptr<SandHook::HookTrampoline> hookTrampoline(
+            trampolineManager.installReplacementTrampoline(originMethod, hookMethod, backupMethod));
     if (hookTrampoline != nullptr) {
         originMethod->setQuickCodeEntry(hookTrampoline->replacement->getCode());
         void* entryPointFormInterpreter = hookMethod->getInterpreterCodeEntry();
@@ -414,7 +415,7 @@ extern "C"
 JNIEXPORT void JNICALL
 Java_com_swift_sandhook_SandHook_MakeInitializedClassVisibilyInitialized(JNIEnv *env, jclass clazz,
                                                                          jlong self) {
-    MakeInitializedClassVisibilyInitialized(reinterpret_cast<void*>(self));
+    MakeInitializedClassVisibilyInitialized(env, reinterpret_cast<void*>(self));
 }
 extern "C"
 JNIEXPORT void* findSym(const char *elf, const char *sym_name) {

--- a/hooklib/src/main/cpp/utils/offset.cpp
+++ b/hooklib/src/main/cpp/utils/offset.cpp
@@ -56,4 +56,10 @@ namespace SandHook {
         return -1;
     }
 
+    template int Offset::findOffset(void *start, size_t len, size_t step, void* value);
+    template int Offset::findOffsetWithCB1(void *start, size_t len, size_t step,
+                                           bool (*func)(int, void*));
+    template int Offset::findOffsetWithCB2(void *start1, void *start2, size_t len, size_t step,
+                                           bool (*func)(void*, void*));
+
 }


### PR DESCRIPTION
1. fix dex_method_idx offset value on android 12;
2. fix class_linker offset value in the runtime class;
3. fix a memory  leak.